### PR TITLE
PKGBUILD and AUR instructions

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Sarah Kraßnigg <buckling.spring@mailbox.org>
 _pkgname=lightdm-tty
-pkgname=lightdm-webkit2-theme-tty
-pkgver=1.0.0
+pkgname=lightdm-webkit2-theme-tty-git
+pkgver=VERSION
 pkgrel=1
 pkgdesc="A simple terminal style theme for lightdm-webkit2-greeter"
 arch=('any')
@@ -12,7 +12,12 @@ makedepends=('git')
 source=("git+https://github.com/eNzyOfficial/${_pkgname}.git")
 md5sums=('SKIP')
 
+pkgver() {
+    cd "$srcdir/${_pkgname}"
+    printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
 package() {
     install -dm755 "$pkgdir/usr/share/lightdm-webkit/themes/tty"
-    cp -r "$srcdir/$_pkgname/"* "$pkgdir/usr/share/lightdm-webkit/themes/tty/"
+    cp -r "$srcdir/${_pkgname}/"* "$pkgdir/usr/share/lightdm-webkit/themes/tty/"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,18 @@
+# Maintainer: Sarah Kraßnigg <buckling.spring@mailbox.org>
+_pkgname=lightdm-tty
+pkgname=lightdm-webkit2-theme-tty
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="A simple terminal style theme for lightdm-webkit2-greeter"
+arch=('any')
+url="https://github.com/eNzyOfficial/lightdm-tty"
+license=('WTFPL')
+depends=('lightdm-webkit2-greeter')
+makedepends=('git')
+source=("git+https://github.com/eNzyOfficial/${_pkgname}.git")
+md5sums=('SKIP')
+
+package() {
+    install -dm755 "$pkgdir/usr/share/lightdm-webkit/themes/lightdm-tty"
+    cp -r "$srcdir/$_pkgname/"* "$pkgdir/usr/share/lightdm-webkit/themes/lightdm-tty/"
+}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,7 +9,7 @@ url="https://github.com/eNzyOfficial/lightdm-tty"
 license=('WTFPL')
 depends=('lightdm-webkit2-greeter')
 makedepends=('git')
-source=("git+https://github.com/eNzyOfficial/${_pkgname}.git")
+source=("lightdm-tty::git+https://github.com/eNzyOfficial/${_pkgname}.git")
 md5sums=('SKIP')
 
 pkgver() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,6 +13,6 @@ source=("git+https://github.com/eNzyOfficial/${_pkgname}.git")
 md5sums=('SKIP')
 
 package() {
-    install -dm755 "$pkgdir/usr/share/lightdm-webkit/themes/lightdm-tty"
-    cp -r "$srcdir/$_pkgname/"* "$pkgdir/usr/share/lightdm-webkit/themes/lightdm-tty/"
+    install -dm755 "$pkgdir/usr/share/lightdm-webkit/themes/tty"
+    cp -r "$srcdir/$_pkgname/"* "$pkgdir/usr/share/lightdm-webkit/themes/tty/"
 }

--- a/README.MD
+++ b/README.MD
@@ -19,6 +19,13 @@ A simple terminal style theme for lightdm-webkit2-greeter
 
 You can run `./test.sh` to try it out if you like!
 
+### Arch Linux
+lightdm-tty is available from the [Arch User Repository (AUR)](https://aur.archlinux.org/packages/lightdm-webkit2-theme-tty-git/). Install it with your favourite AUR helper, for example:
+
+`pacaur -S lightdm-webkit2-theme-tty-git`
+
+If you don't want to use an AUR helper, you can always build the package manually from the PKGBUILD included in the repository.
+
 ## Features
 
 * Command history using ↑ and ↓


### PR DESCRIPTION
A lightdm-tty package is already available at https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=lightdm-webkit2-theme-tty-git. This PR merely adds the PKGBUILD and readme instructions.